### PR TITLE
Fix for more cross-capatability

### DIFF
--- a/fireproof-bots/data-final-fixes.lua
+++ b/fireproof-bots/data-final-fixes.lua
@@ -1,4 +1,5 @@
 for _, bot in pairs(data.raw["construction-robot"]) do
+	bot = bot or {}
 	bot.resistances = bot.resistances or {}
 	table.insert(bot.resistances, {type = "fire", percent = 100})
 end


### PR DESCRIPTION
This change makes it so if the construction robot is not a table (which it should always be) it gets ignored.